### PR TITLE
Add ability to run the Hub locally for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY        seed-db.sh /docker-entrypoint-initdb.d
 RUN         chmod +x /docker-entrypoint-initdb.d/seed-db.sh
 
 # Install dependencies that are required for loading data from a Python script
-RUN         apt-get install -y python3 python3-pandas python3-pip libmysqlclient-dev
+RUN         apt-get update && apt-get install -y python3 python3-pandas python3-pip libmysqlclient-dev
 RUN         pip3 install mysqlclient xlrd pyyaml
 
 # Install and setup supervisord

--- a/README.md
+++ b/README.md
@@ -4,14 +4,30 @@ A docker image for the [Research Hub](https://research-hub.auckland.ac.nz/) data
 MySQL and Cron are run via Supervisord. Cron runs a script that dumps the MySQL database into the /data/ folder, which you can mount onto the host filesystem.
 
 # Running the database container locally
-Follow steps 1 and 2 from the [Research Hub Deploy project](https://github.com/UoA-eResearch/research-hub-deploy#research-hub-deploy).
+Follow the instructions for running the database container locally in [Research Hub Deploy project](https://github.com/UoA-eResearch/research-hub-deploy#research-hub-deploy).
+
+You should place the database spreadsheet in `config/db/database.xlsx` in the cloned Deploy project directory.
 
 To build the database container:
 ```bash
-./hubby compose build db
+./hubby build db
 ```
 
 To run the database container:
 ```bash
-./hubby compose run -p 3306:3306 db
+./hubby up db
 ```
+
+You can then examine the database using the MySQL client:
+```bash
+./hubby compose exec db bash
+mysql -p
+```
+You can find the MySQL account password in [the Deploy project](https://github.com/UoA-eResearch/research-hub-deploy#research-hub-deploy).
+
+If you make changes to the spreadsheet, you will need to run the following commands in order for the database container to reseed with the changed data:
+```bash
+./hubby cleandb
+./hubby up db
+```
+You will be prompted for your sudo password on the `cleandb` step.

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,4 +1,4 @@
-version: '3.0'
+version: '3.4'
 services:
   db:
     image: ${DOCKER_REGISTRY_URI}/${DOCKER_IMAGE_NAME}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.0'
+version: '3.4'
 services:
   db:
     build:

--- a/seed_db.py
+++ b/seed_db.py
@@ -78,10 +78,11 @@ if __name__ == "__main__":
 
         rows = [tuple(row) for row in rows]
 
-        # Insert data into database
+        # Insert data into database	
         with closing(get_connection(db_config)) as con:
-            with con as cursor:
+            with con.cursor() as cursor:
                 cursor.execute('SET NAMES utf8mb4')
                 cursor.execute("SET CHARACTER SET utf8mb4")
                 cursor.execute("SET character_set_connection=utf8mb4")
                 cursor.executemany(query, rows)
+            con.commit()


### PR DESCRIPTION
This is part of a Hub-wide feature to run the complete Hub locally for development. The changes in this repository will enable running the db project locally.

The feature will be progressively merged into different repositories. See the deploy project branch for more information.